### PR TITLE
fix: include compiled assets: `lib/` as it does not depend on arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,3 @@ node_modules
 temp
 *.temp
 *.tmp
-
-# Compiled output
-lib/

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var _commander = require('commander');
+
+var _commander2 = _interopRequireDefault(_commander);
+
+var _package = require('../package.json');
+
+var _package2 = _interopRequireDefault(_package);
+
+var _converter = require('./converter');
+
+var _converter2 = _interopRequireDefault(_converter);
+
+var _reader = require('./reader');
+
+var _reader2 = _interopRequireDefault(_reader);
+
+var _sqlFormatter = require('./sql-formatter');
+
+var _sqlFormatter2 = _interopRequireDefault(_sqlFormatter);
+
+var _fs = require('fs');
+
+var _fs2 = _interopRequireDefault(_fs);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var reader = new _reader2.default();;
+var formatters = new _sqlFormatter2.default();;
+var converter = new _converter2.default(reader, formatters);;
+
+formatters['table'] = new _sqlFormatter2.default();
+
+var file = undefined;
+var outputDirectory = undefined;
+
+_commander2.default.version(_package2.default.version).arguments('<sqlFile> [output]').action(function (sqlFile, output) {
+    outputDirectory = output;
+    file = sqlFile;
+});
+
+_commander2.default.parse(process.argv);
+
+outputDirectory = outputDirectory || './output';
+
+if (!file) {
+    console.error('no sqlFile provided');
+    process.exit(1);
+}
+
+var contents = _fs2.default.readFileSync(file, 'utf8');
+converter.createFiles(contents, outputDirectory);

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _filendir = require('filendir');
+
+var _filendir2 = _interopRequireDefault(_filendir);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var Converter = (function () {
+    function Converter(reader, formatters) {
+        _classCallCheck(this, Converter);
+
+        this.reader = reader;
+        this.formatters = formatters;
+    }
+
+    _createClass(Converter, [{
+        key: 'toGraph',
+        value: function toGraph(input) {
+            var _this = this;
+
+            var results = this.reader.parse(input);
+
+            return results.map(function (r) {
+                return {
+                    type: r.type,
+                    name: r.name,
+                    content: (_this.formatters[r.type] || _this.formatters).format(r)
+                };
+            });
+        }
+    }, {
+        key: 'createFiles',
+        value: function createFiles(input, outputLocation) {
+            var _this2 = this;
+
+            var graph = this.toGraph(input);
+            var json = {
+                databaseChangeLog: []
+            };
+
+            graph.forEach(function (g) {
+                var relativePath = _this2.getFilePath(g.type, g.name);
+
+                _filendir2.default.writeFileSync(_path2.default.join(outputLocation, relativePath), g.content);
+
+                json.databaseChangeLog.push({
+                    include: {
+                        file: relativePath
+                    }
+                });
+            });
+
+            _filendir2.default.writeFileSync(_path2.default.join(outputLocation, 'changelog.json'), JSON.stringify(json, null, 2));
+        }
+    }, {
+        key: 'getFilePath',
+        value: function getFilePath(type, name) {
+            var folderType = type === 'table' ? 'tables' : 'data';
+            return 'migrations/baseline/' + folderType + '/' + name + '.sql';
+        }
+    }]);
+
+    return Converter;
+})();
+
+exports.default = Converter;

--- a/lib/converter.spec.js
+++ b/lib/converter.spec.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var _chai = require('chai');
+
+var _chai2 = _interopRequireDefault(_chai);
+
+var _converter = require('./converter');
+
+var _converter2 = _interopRequireDefault(_converter);
+
+var _reader = require('./reader');
+
+var _reader2 = _interopRequireDefault(_reader);
+
+var _sqlFormatter = require('./sql-formatter');
+
+var _sqlFormatter2 = _interopRequireDefault(_sqlFormatter);
+
+var _fs = require('fs');
+
+var _fs2 = _interopRequireDefault(_fs);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_chai2.default.should();
+
+describe('Converter', function () {
+    var converter = undefined;
+    var reader = undefined;
+    var formatters = undefined;
+
+    beforeEach(function () {
+        formatters = new _sqlFormatter2.default();
+        formatters['table'] = new _sqlFormatter2.default();
+
+        reader = new _reader2.default();
+
+        converter = new _converter2.default(reader, formatters);
+    });
+
+    describe('graph', function () {
+        it('should convert single create table statement to object graph', function () {
+            var input = 'create table if not exists `my_table` ();';
+            var result = converter.toGraph(input);
+
+            result.length.should.equal(1);
+            result[0].type.should.equal('table');
+            result[0].name.should.equal('my_table');
+            result[0].content.should.equal('--liquibase formatted sql\n\n--changeset converter:baseline dbms:mysql\n' + input + '\n');
+        });
+
+        it('should convert single insert into statement to object graph', function () {
+            var input = 'INSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 1);';
+            var result = converter.toGraph(input);
+
+            result.length.should.equal(1);
+            result[0].type.should.equal('insert');
+            result[0].name.should.equal('my_table');
+            result[0].content.should.equal('--liquibase formatted sql\n\n--changeset converter:baseline dbms:mysql\n' + input + '\n');
+        });
+
+        it('should convert basic.sql file to object graph', function () {
+            var input = _fs2.default.readFileSync(_path2.default.resolve(__dirname, '../testdata/basic.sql'), 'utf8');
+            var result = converter.toGraph(input);
+
+            result.length.should.equal(2);
+
+            result[0].type.should.equal('table');
+            result[0].name.should.equal('my_table');
+
+            result[1].type.should.equal('insert');
+            result[1].name.should.equal('my_table');
+        });
+    });
+
+    describe('files', function () {
+        it('should create files on disk based on basic.sql file', function () {
+            var input = _fs2.default.readFileSync(_path2.default.resolve(__dirname, '../testdata/basic.sql'), 'utf8');
+            var result = converter.createFiles(input, _path2.default.resolve(__dirname, '../testdata/temp'));
+
+            // check that files exist and are accessible
+            _fs2.default.accessSync(_path2.default.resolve(__dirname, '../testdata/temp/changelog.json'));
+            _fs2.default.accessSync(_path2.default.resolve(__dirname, '../testdata/temp/migrations/baseline/tables/my_table.sql'));
+            _fs2.default.accessSync(_path2.default.resolve(__dirname, '../testdata/temp/migrations/baseline/data/my_table.sql'));
+        });
+    });
+});

--- a/lib/formatter-base.js
+++ b/lib/formatter-base.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var FormatterBase = (function () {
+    function FormatterBase() {
+        _classCallCheck(this, FormatterBase);
+    }
+
+    _createClass(FormatterBase, [{
+        key: 'getPrefix',
+        value: function getPrefix() {
+            return '--liquibase formatted sql';
+        }
+    }]);
+
+    return FormatterBase;
+})();
+
+exports.default = FormatterBase;

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var Reader = (function () {
+    function Reader() {
+        _classCallCheck(this, Reader);
+    }
+
+    _createClass(Reader, [{
+        key: 'parse',
+        value: function parse(input) {
+            var matches = [];
+            Reader.expressions.forEach(function (exp) {
+                var startMatch;
+
+                exp.pattern[0].lastIndex = 0;
+                exp.pattern[1].lastIndex = 0;
+
+                while (startMatch = exp.pattern[0].exec(input)) {
+                    var startIndex = startMatch.index;
+                    var endIndex = input.length;
+                    var endMatch = exp.pattern[1].exec(input.substring(startIndex + startMatch[0].length));
+
+                    if (endMatch) {
+                        endIndex = startIndex + startMatch[0].length + endMatch.index + endMatch[0].length;
+                    }
+
+                    matches.push({
+                        type: exp.type,
+                        index: startIndex,
+                        match: input.substring(startIndex, endIndex),
+                        name: startMatch[exp.nameIndex]
+                    });
+                }
+            });
+
+            return matches;
+        }
+    }]);
+
+    return Reader;
+})();
+
+Reader.expressions = [{ type: 'table', pattern: [/\bcreate\s+table\s+(if\s+not\s+exists\s+)?`?([^\s`]+)`?/gi, /;(?=[ \t]*$)/mi], nameIndex: 2 }, { type: 'insert', pattern: [/\binsert\s+into\s*`?([^\s`]+)`?/gi, /;(?=[ \t]*$)/mi], nameIndex: 1 }];
+exports.default = Reader;

--- a/lib/reader.spec.js
+++ b/lib/reader.spec.js
@@ -1,0 +1,137 @@
+'use strict';
+
+var _chai = require('chai');
+
+var _chai2 = _interopRequireDefault(_chai);
+
+var _reader = require('./reader');
+
+var _reader2 = _interopRequireDefault(_reader);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_chai2.default.should();
+
+describe('Reader', function () {
+    var reader = undefined;
+
+    beforeEach(function () {
+        reader = new _reader2.default();
+    });
+
+    describe('create table', function () {
+        it('should read single line create table statement', function () {
+            var result = reader.parse('create table if not exists `my_table` ();');
+
+            result.length.should.equal(1);
+            result[0].type.should.equal('table');
+            result[0].name.should.equal('my_table');
+            result[0].match.should.equal('create table if not exists `my_table` ();');
+        });
+
+        it('should read single line create table statement without exists', function () {
+            var result = reader.parse('create table `my_table` ();');
+
+            result.length.should.equal(1);
+            result[0].type.should.equal('table');
+            result[0].name.should.equal('my_table');
+            result[0].match.should.equal('create table `my_table` ();');
+        });
+
+        it('should read create table statement without back ticks', function () {
+            var result = reader.parse('create table if not exists my_table ();');
+
+            result.length.should.equal(1);
+            result[0].type.should.equal('table');
+            result[0].name.should.equal('my_table');
+            result[0].match.should.equal('create table if not exists my_table ();');
+        });
+
+        it('should read multi line create table statement', function () {
+            var result = reader.parse('create table if not exists `my_table` (\n);');
+
+            result.length.should.equal(1);
+            result[0].type.should.equal('table');
+            result[0].name.should.equal('my_table');
+            result[0].match.should.equal('create table if not exists `my_table` (\n);');
+        });
+
+        it('should read multi line create table statement with trailing whitespace', function () {
+            var result = reader.parse('create table if not exists `my_table` (\n);  \n');
+
+            result.length.should.equal(1);
+            result[0].type.should.equal('table');
+            result[0].name.should.equal('my_table');
+            result[0].match.should.equal('create table if not exists `my_table` (\n);');
+        });
+
+        it('should read multiple create table statements', function () {
+            var result = reader.parse('create table if not exists `table1` ();\n\ncreate table if not exists `table2` ();');
+
+            result.length.should.equal(2);
+
+            result[0].type.should.equal('table');
+            result[0].name.should.equal('table1');
+            result[0].match.should.equal('create table if not exists `table1` ();');
+
+            result[1].type.should.equal('table');
+            result[1].name.should.equal('table2');
+            result[1].match.should.equal('create table if not exists `table2` ();');
+        });
+    });
+
+    describe('insert into table', function () {
+        it('should read single line insert statement', function () {
+            var result = reader.parse('INSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 1);');
+
+            result.length.should.equal(1);
+            result[0].type.should.equal('insert');
+            result[0].name.should.equal('my_table');
+        });
+
+        it('should read multi line insert statement with multiple rows', function () {
+            var result = reader.parse('INSERT INTO `my_table` (`key`, `value`) VALUES\n(\'my_key\', 1),\n;(\'my_key_2\', 2)');
+
+            result.length.should.equal(1);
+            result[0].type.should.equal('insert');
+            result[0].name.should.equal('my_table');
+        });
+
+        it('should read single line insert statement that contains `;` as part of the values', function () {
+            var result = reader.parse('INSERT INTO `my_table` (`key`, `value`) VALUES (\'my;key\', 1);');
+
+            result.length.should.equal(1);
+            result[0].type.should.equal('insert');
+            result[0].name.should.equal('my_table');
+            result[0].match.should.equal('INSERT INTO `my_table` (`key`, `value`) VALUES (\'my;key\', 1);');
+        });
+
+        it('should read multiple single line insert statements', function () {
+            var result = reader.parse('INSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 1);\nINSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 2);');
+
+            result.length.should.equal(2);
+
+            result[0].type.should.equal('insert');
+            result[0].name.should.equal('my_table');
+            result[0].match.should.equal('INSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 1);');
+
+            result[1].type.should.equal('insert');
+            result[1].name.should.equal('my_table');
+            result[1].match.should.equal('INSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 2);');
+        });
+
+        it('should read multiple single line insert statements with trailing whitespace', function () {
+            var result = reader.parse('INSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 1);\t\n\nINSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 2);\t\n');
+
+            result.length.should.equal(2);
+
+            result[0].type.should.equal('insert');
+            result[0].name.should.equal('my_table');
+            result[0].match.should.equal('INSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 1);');
+
+            result[1].type.should.equal('insert');
+            result[1].name.should.equal('my_table');
+            result[1].match.should.equal('INSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 2);');
+        });
+    });
+});

--- a/lib/sql-formatter.js
+++ b/lib/sql-formatter.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _formatterBase = require('./formatter-base');
+
+var _formatterBase2 = _interopRequireDefault(_formatterBase);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var SqlFormatter = (function (_FormatterBase) {
+    _inherits(SqlFormatter, _FormatterBase);
+
+    function SqlFormatter() {
+        _classCallCheck(this, SqlFormatter);
+
+        return _possibleConstructorReturn(this, Object.getPrototypeOf(SqlFormatter).apply(this, arguments));
+    }
+
+    _createClass(SqlFormatter, [{
+        key: 'format',
+        value: function format(readerResult) {
+            var output = '';
+
+            output += this.getPrefix();
+            output += '\n\n';
+            output += '--changeset converter:baseline dbms:mysql\n';
+            output += readerResult.match;
+            output += '\n';
+
+            return output;
+        }
+    }]);
+
+    return SqlFormatter;
+})(_formatterBase2.default);
+
+exports.default = SqlFormatter;

--- a/lib/sql-formatter.spec.js
+++ b/lib/sql-formatter.spec.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var _chai = require('chai');
+
+var _chai2 = _interopRequireDefault(_chai);
+
+var _sqlFormatter = require('./sql-formatter');
+
+var _sqlFormatter2 = _interopRequireDefault(_sqlFormatter);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_chai2.default.should();
+
+describe('Basic SQL Formatter', function () {
+    var formatter = undefined;
+
+    beforeEach(function () {
+        formatter = new _sqlFormatter2.default();
+    });
+
+    describe('create table', function () {
+        it('should format create table statement', function () {
+            var match = 'create table if not exists `my_table` ();';
+            var result = formatter.format({ match: match });
+
+            result.should.equal('--liquibase formatted sql\n\n--changeset converter:baseline dbms:mysql\n' + match + '\n');
+        });
+    });
+
+    describe('insert into', function () {
+        it('should format insert into statement', function () {
+            var match = 'INSERT INTO `my_table` (`key`, `value`) VALUES (\'my_key\', 1);';
+            var result = formatter.format({ match: match });
+
+            result.should.equal('--liquibase formatted sql\n\n--changeset converter:baseline dbms:mysql\n' + match + '\n');
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The MySql to Liquibase Converter is intended to split up the contents of a single MySql sql file into a series of smaller files that are easier to maintain and version independently.",
   "main": "index.js",
   "scripts": {
-    "compile": "babel --optional runtime -d lib/ src/",
+    "compile": "./node_modules/babel-cli/bin/babel.js --optional runtime -d lib/ src/",
     "prepublish": "npm run compile",
     "start": "babel-node index",
     "test": "gulp test",

--- a/readme.md
+++ b/readme.md
@@ -4,10 +4,8 @@ The MySql to Liquibase Converter is intended to split up the contents of a singl
 
 ## Installation
 
-Clone the repository and install it locally.
-
 ```
-npm install . -g
+npm install -g peopleplan/mysql-liquibase-converter
 ```
 
 ## Usage


### PR DESCRIPTION
Since the compilation is not based on individual architecture, we can even if its _temporary_, commit compiled assets; It's not a bad idea and plus this should close #2.

Captured output:

```
/tmp❯ npm install hongymagic/mysql-liquibase-converter#fix/install -g
/Users/davidhong/.nvm/versions/node/v4.2.1/bin/mysqlbase -> /Users/davidhong/.nvm/versions/node/v4.2.1/lib/node_modules/mysql-liquibase-converter/bin/mysqlbase
/Users/davidhong/.nvm/versions/node/v4.2.1/lib
└─┬ mysql-liquibase-converter@0.1.0  (git+ssh://git@github.com/hongymagic/mysql-liquibase-converter.git#e64830b6ad44499d1e2bf522ba9bb7ca635d6902)
  ├─┬ commander@2.9.0
  │ └── graceful-readlink@1.0.1
  └─┬ filendir@1.0.0
    └─┬ mkdirp@0.5.1
      └── minimist@0.0.8

/tmp❯ mysqlbase
no sqlFile provided
```

README.md has been updated accordingly.
